### PR TITLE
Support IE8 and Rhino

### DIFF
--- a/src/jsonpointer.js
+++ b/src/jsonpointer.js
@@ -345,5 +345,5 @@
 
 }).call((function() {
   'use strict';
-  return (typeof window !== 'undefined' ? window : global);
+  return (typeof window !== 'undefined' ? window : this);
 })());


### PR DESCRIPTION
I'd like to use your jsonpointer.js module on IE8 and Rhino (javascript implementation in java).
But it is used unsupported method or variable currently.
- IE8 does not support Array.isArray and Array.forEach.
- Rhino(version 1.7) does not support Array.isArray and 'global' variable.
